### PR TITLE
correct "Key" - wrong spelling "Pey"

### DIFF
--- a/TouchPiano.ts
+++ b/TouchPiano.ts
@@ -74,7 +74,7 @@ enum RGB_COLOR {
 //% weight=20 color=#3333FF icon="\uf001"
 namespace WSTouchPiano {
     //% blockId=tp_press 
-    //% block="Pey|%index|is pressed"
+    //% block="Key|%index|is pressed"
     //% weight=100
     export function TP_Press(index: TP_PIANO): boolean {
         let TPval = pins.i2cReadNumber(0x57, NumberFormat.UInt16BE);


### PR DESCRIPTION
"Key" is wrongly spelled as "Pey" 